### PR TITLE
Bugfix in Tensorboard callback

### DIFF
--- a/Keras/Callbacks.cs
+++ b/Keras/Callbacks.cs
@@ -313,7 +313,7 @@ namespace Keras.Callbacks
             Parameters["embeddings_freq"] = embeddings_freq;
             Parameters["embeddings_layer_names"] = embeddings_layer_names;
             Parameters["embeddings_metadata"] = embeddings_metadata;
-            Parameters["embeddings_data"] = embeddings_data.PyObject;
+            Parameters["embeddings_data"] = embeddings_data?.PyObject;
             Parameters["update_freq"] = update_freq;
 
             PyInstance = Instance.keras.callbacks.TensorBoard;

--- a/Keras/Keras.csproj
+++ b/Keras/Keras.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>Keras.NET</PackageId>
-    <Version>3.6.1.6</Version>
+    <Version>3.6.1.7</Version>
     <Authors>SciSharp Team</Authors>
     <Product>Keras.NET</Product>
     <Description>C# bindings for Keras on Win64 - Keras.NET is a high-level neural networks API, capable of running on top of TensorFlow, CNTK, or Theano. </Description>


### PR DESCRIPTION
Check for null (default value) to prevent null argument exception.