### PR TITLE
fix "unknown kernel_regularizer" exception when not specified

### DIFF
--- a/Keras/Layers/Core.cs
+++ b/Keras/Layers/Core.cs
@@ -66,7 +66,7 @@
             this["use_bias"] = use_bias;
             this["kernel_initializer"] = kernel_initializer ?? "glorot_uniform";
             this["bias_initializer"] = bias_initializer;
-            this["kernel_regularizer"] = kernel_regularizer ?? "";
+            this["kernel_regularizer"] = kernel_regularizer;
             this["bias_regularizer"] = bias_regularizer;
             this["activity_regularizer"] = activity_regularizer;
             this["kernel_constraint"] = kernel_constraint;


### PR DESCRIPTION
Checked out and started XOR samples and got exception  on `new Dense()`
Python.Runtime.PythonException: 'ValueError : Unknown regularizer: '

I found an attempt to handle it in Base.cs
`                 if (item.Value != null && !string.IsNullOrWhiteSpace(item.Value.ToString()))
                {
                    kwargs[item.Key] = ToPython(item.Value);
                }
`
but pythonObject.Value.ToString() always return "PythonObject" so it doesn't look like filtering empty values.

proposed quick fix works well.
