### PR TITLE
Fix Missing Batch_Input_Shape in LTSM Layer

### DIFF
--- a/Keras/Layers/Recurrent.cs
+++ b/Keras/Layers/Recurrent.cs
@@ -340,7 +340,7 @@ namespace Keras.Layers
     public class LSTM : RNN
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="GRU" /> class.
+        /// Initializes a new instance of the <see cref="LSTM" /> class.
         /// </summary>
         /// <param name="units">Positive integer, dimensionality of the output space.</param>
         /// <param name="activation">Activation function to use (see activations). Default: hyperbolic tangent (tanh). If you pass None, no activation is applied (ie. "linear" activation: a(x) = x).</param>
@@ -365,11 +365,13 @@ namespace Keras.Layers
         /// <param name="go_backwards">Boolean (default False). If True, process the input sequence backwards and return the reversed sequence.</param>
         /// <param name="stateful">Boolean (default False). If True, the last state for each sample at index i in a batch will be used as initial state for the sample of index i in the following batch.</param>
         /// <param name="unroll">Boolean (default False). If True, the network will be unrolled, else a symbolic loop will be used. Unrolling can speed-up a RNN, although it tends to be more memory-intensive. Unrolling is only suitable for short sequences.</param>
-        public LSTM(int units, string activation = "tanh", string recurrent_activation = "hard_sigmoid", bool use_bias = true, string kernel_initializer = "glorot_uniform"
-            , string recurrent_initializer = "orthogonal", string bias_initializer = "zeros", bool unit_forget_bias = true, string kernel_regularizer = "",
+        /// <param name="batch_input_shape">Optional input batch size (integer or None).</param>
+
+        public LSTM(int units, string activation = "tanh", string recurrent_activation = "hard_sigmoid", bool use_bias = true, StringOrInstance kernel_initializer = null
+            , StringOrInstance recurrent_initializer = null, string bias_initializer = "zeros", bool unit_forget_bias = true, string kernel_regularizer = "",
             string recurrent_regularizer = "", string bias_regularizer = "", string activity_regularizer = "", string kernel_constraint = "", string recurrent_constraint = "",
             string bias_constraint = "", float dropout = 0.0f, float recurrent_dropout = 0.0f, int implementation = 1, bool return_sequences = false, bool return_state = false,
-            bool go_backwards = false, bool stateful = false, bool unroll = false)
+            bool go_backwards = false, bool stateful = false, bool unroll = false, Shape batch_input_shape = null)
         {
             Parameters["units"] = units;
             Parameters["activation"] = activation;
@@ -394,6 +396,7 @@ namespace Keras.Layers
             Parameters["go_backwards"] = go_backwards;
             Parameters["stateful"] = stateful;
             Parameters["unroll"] = unroll;
+            Parameters["batch_input_shape"] = batch_input_shape;
             PyInstance = Instance.keras.layers.LSTM;
             Init();
         }

--- a/Keras/Layers/Recurrent.cs
+++ b/Keras/Layers/Recurrent.cs
@@ -366,7 +366,6 @@ namespace Keras.Layers
         /// <param name="stateful">Boolean (default False). If True, the last state for each sample at index i in a batch will be used as initial state for the sample of index i in the following batch.</param>
         /// <param name="unroll">Boolean (default False). If True, the network will be unrolled, else a symbolic loop will be used. Unrolling can speed-up a RNN, although it tends to be more memory-intensive. Unrolling is only suitable for short sequences.</param>
         /// <param name="batch_input_shape">Optional input batch size (integer or None).</param>
-
         public LSTM(int units, string activation = "tanh", string recurrent_activation = "hard_sigmoid", bool use_bias = true, StringOrInstance kernel_initializer = null
             , StringOrInstance recurrent_initializer = null, string bias_initializer = "zeros", bool unit_forget_bias = true, string kernel_regularizer = "",
             string recurrent_regularizer = "", string bias_regularizer = "", string activity_regularizer = "", string kernel_constraint = "", string recurrent_constraint = "",


### PR DESCRIPTION
This fixes the missing batch_input_shape for the LTSM layer and also adds the possibility to use customized initializers.

Adding the batch_input_shape allows to use the stateful parameter.

Maybe the batch_input_shape can be added for the RNN base layer, but I didn't check the documentation for all sublayers if that is acceptable.