### PR TITLE
fixing multi-output model

### DIFF
--- a/Keras/Models/Model.cs
+++ b/Keras/Models/Model.cs
@@ -49,7 +49,7 @@
                 outputList.Add(item.PyInstance);
             }
 
-            PyInstance = Instance.keras.models.Model(inputList, outputList[0]);
+            PyInstance = Instance.keras.models.Model(inputList, outputList);
         }
 
         /// <summary>


### PR DESCRIPTION
 Discovered that C# Model constructor was only passing the first output from the constructor instead of the entire list. Once fixed, multi-output models worked.